### PR TITLE
Initialize channel inside the create() method

### DIFF
--- a/src/net/Timer.h
+++ b/src/net/Timer.h
@@ -32,6 +32,8 @@ public:
     int fd() { return fd_; }
 
 private:
+    void expiredEventHandler(uint32_t revents, void *data);
+
     bool repeat_;
     TimerCallback cb_;
     Timestamp interval_;

--- a/src/net/test/Timer_unittest.cpp
+++ b/src/net/test/Timer_unittest.cpp
@@ -11,22 +11,6 @@ void timerCallback(void)
     std::cout << "In timer callback" << std::endl;
 }
 
-void eventCallback(uint32_t revents, void *data)
-{
-    cppevt::Timer *timer = static_cast<cppevt::Timer*>(data);
-
-    if (revents & EPOLLIN)
-    {
-        std::cout << "EPOLLIN" << std::endl;
-
-        // should call read() because fd is in edge-triggered mode
-        uint64_t numOfExpirations = 0;
-        ::read(timer->fd(), &numOfExpirations, sizeof(uint64_t));
-    }
-
-    timer->callTimerCallback();
-}
-
 int main(int argc, char *argv[])
 {
     try
@@ -39,9 +23,6 @@ int main(int argc, char *argv[])
         timer.create();
         timer.set(expiration, interval);
         timer.setCallback(timerCallback);
-        timer.channel()->set_events(EPOLLIN | EPOLLET);
-        timer.channel()->setEventCallback(eventCallback);
-        timer.channel()->setEventData(static_cast<void*>(&timer));
 
         cppevt::EventLoop eventLoop;
         eventLoop.newEpoll();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced timer responsiveness with event-driven handling for more efficient callbacks.

- **Refactor**
  - Streamlined timer event setup by removing manual event configuration and simplifying callback invocation.

- **Tests**
  - Updated timer unit tests to align with the new event-driven timer behavior and removed obsolete callback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->